### PR TITLE
:sparkles: Use more robust tgenv tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 temp/
 .tmp/
 tmp/
+*.log
 
 # Compiled code
 build/

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ you get all of the above with minimal overhead. Also see [why use terragrunt].
 - **[terragrunt]** is a terraform wrapper that helps keep code DRY, maintainable, and safe to automate. See [why use terragrunt].
 - **[atlantis]** is a terraform ci/cd tool that makes automating terraform via good git practices easy. No need for jenkins and you can deploy it anywhere.
 - **[tfenv]** is a version manager for terraform making it easy to set, install and use multiple versions of terraform in a single config repo.
-- **[tgenv]** is a similar version manager for terragrunt.
+- **[tgenv]** is a similar version manager for terragrunt. Forked from [tfenv].
 - **[tfmask]** keeps ci/cd of terraform secure by filtering passwords and secrets in terraform output from plans and applies.
 - **[nu-atlantis]** custom atlantis image with bash wrappers for everything above and some enhancements:
   - sets opinionated atlantis config defaults so you don't need atlantis config in your tf repo.
@@ -148,7 +148,6 @@ If forking this repo, you'll want to customize the `Makefile` to deploy to your 
 - [gruntwork] for terragrunt
 - [runatlantis team] for atlantis
 - [tfutils] for tfenv
-- [cunymatthieu] for tgenv
 - [cloudposse] for tfmask
 - [thlorenz] for doctoc
 
@@ -158,14 +157,13 @@ If forking this repo, you'll want to customize the `Makefile` to deploy to your 
 [why use terragrunt]: https://transcend.io/blog/why-we-use-terragrunt
 [atlantis]: https://www.runatlantis.io/
 [tfenv]: https://github.com/tfutils/tfenv
-[tgenv]: https://github.com/cunymatthieu/tgenv
+[tgenv]: https://github.com/taosmountain/tgenv
 [tfmask]: https://github.com/cloudposse/tfmask
 [nu-atlantis]: ./README.md
 [hashicorp]: https://www.hashicorp.com/
 [gruntwork]: https://gruntwork.io/
 [runatlantis team]: https://github.com/runatlantis
 [tfutils]: https://github.com/tfutils
-[cunymatthieu]: https://github.com/cunymatthieu
 [cloudposse]: https://github.com/cloudposse/tfmask
 [thlorenz]: https://github.com/thlorenz/doctoc
 [hoppalotta]: https://github.com/hoppalotta

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,7 +13,7 @@ ARG TERRAFORM_VERSION=0.13.5
 ARG TERRAGRUNT_VERSION=0.25.5
 ARG TFMASK_VERSION=0.7.0
 ARG TFENV_VERSION=v2.0.0
-ARG TGENV_VERSION=v0.0.3
+ARG TGENV_VERSION=0.1.0
 
 # Remove atlantis default terraform binary to ensure no conflicts
 RUN rm -rf /usr/local/bin/terraform
@@ -23,7 +23,7 @@ RUN git clone -b ${TFENV_VERSION} https://github.com/tfutils/tfenv.git ${WORKDIR
 RUN ln -s ${WORKDIR}/.tfenv/bin/* /usr/local/bin
 RUN tfenv install ${TERRAFORM_VERSION}; tfenv use ${TERRAFORM_VERSION}
 
-RUN git clone -b ${TGENV_VERSION} https://github.com/cunymatthieu/tgenv.git ${WORKDIR}/.tgenv
+RUN git clone -b ${TGENV_VERSION} https://github.com/taosmountain/tgenv.git ${WORKDIR}/.tgenv
 RUN ln -s ${WORKDIR}/.tgenv/bin/* /usr/local/bin
 RUN tgenv install ${TERRAGRUNT_VERSION}; tgenv use ${TERRAGRUNT_VERSION}
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -40,7 +40,7 @@ ARG TERRAFORM_VERSION=0.13.5
 ARG TERRAGRUNT_VERSION=0.25.5
 ARG TFMASK_VERSION=0.7.0
 ARG TFENV_VERSION=v2.0.0
-ARG TGENV_VERSION=v0.0.3
+ARG TGENV_VERSION=0.1.0
 ARG CREDSTASH_PROVIDER_VERSION=v0.5.0
 
 # Remove atlantis default terraform binary to ensure no conflicts
@@ -51,7 +51,7 @@ RUN git clone -b ${TFENV_VERSION} https://github.com/tfutils/tfenv.git ${WORKDIR
 RUN ln -s ${WORKDIR}/.tfenv/bin/* /usr/local/bin
 RUN tfenv install ${TERRAFORM_VERSION}; tfenv use ${TERRAFORM_VERSION}
 
-RUN git clone -b ${TGENV_VERSION} https://github.com/cunymatthieu/tgenv.git ${WORKDIR}/.tgenv
+RUN git clone -b ${TGENV_VERSION} https://github.com/taosmountain/tgenv.git ${WORKDIR}/.tgenv
 RUN ln -s ${WORKDIR}/.tgenv/bin/* /usr/local/bin
 RUN tgenv install ${TERRAGRUNT_VERSION}; tgenv use ${TERRAGRUNT_VERSION}
 


### PR DESCRIPTION
### Description
Previous tgenv didn't automatically install terragrunt versions based on `.terragrunt-version` file. This is problematic for ci/cd and maintainability. Ended up forking tfenv and created our own [tgenv here](https://github.com/taosmountain/tgenv)

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself / the copyright holder to the AUTH
